### PR TITLE
Fix for do-prepared* with return-generated-keys.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .project
 bin
 target
+\#*\#

--- a/src/main/clojure/clojure/java/jdbc.clj
+++ b/src/main/clojure/clojure/java/jdbc.clj
@@ -222,12 +222,15 @@ generated keys are returned (as a map)." }
         template (apply str (interpose "," (replicate n "?")))
         columns (if (seq column-names)
                   (format "(%s)" (apply str (interpose "," column-strs)))
-                  "")]
-    (apply do-prepared*
-           return-keys
-           (format "INSERT INTO %s %s VALUES (%s)"
-                   (as-identifier table) columns template)
-           value-groups)))
+                  "")
+        sql-template (format "INSERT INTO %s %s VALUES (%s)"
+                             (as-identifier table) columns template)]
+    (if return-keys
+      (do-single-prepared-get-keys* sql-template (first value-groups))
+      (apply do-prepared*
+             return-keys
+             sql-template
+             value-groups))))
 
 (defn insert-rows
   "Inserts complete rows into a table. Each row is a vector of values for


### PR DESCRIPTION
This fix is expected not to break the public interface of current version.

JDBC driver for PostgreSQL and ms-sql does not support returning of generated keys from statements executed in batch. The SQL exception was thrown when 'do-prepared*' was called with 'return-keys' set to true. Currently only the function 'insert-values' calls a new method 'do-single-prepared-get-keys*' when single relation is inserted.
