### PR TITLE
Simplified Connection Pool Example

### DIFF
--- a/doc/clojure/java/jdbc/ConnectionPooling.md
+++ b/doc/clojure/java/jdbc/ConnectionPooling.md
@@ -13,40 +13,19 @@ In Maven, it would be:
       <version>0.9.1.2</version>
     </dependency>
 
-## Create the pooled datasource from your db-spec
-Define your db-spec as usual, for example (for MySQL):
-
-    (def db-spec 
-      {:classname "com.mysql.jdbc.Driver"
-       :subprotocol "mysql"
-       :subname "//127.0.0.1:3306/mydb"
-       :user "myaccount"
-       :password "secret"})
-
-Import the c3p0 class as part of your namespace declaration, for example:
+Import the c3p0 class as part of your namespace declaration, for example  (for postgresql):
 
     (ns example.db
       (:import com.mchange.v2.c3p0.ComboPooledDataSource))
 
-Define a function that creates a pooled datasource:
+    (def db (delay {:datasource (doto (ComboPooledDataSource.)
+                                  (.setDriverClass "org.postgresql.Driver")
+                                  (.setJdbcUrl "jdbc:postgresql://DB-HOST:DB-PORT/DB-NAME")
+                                  (.setUser "DB-USER")
+                                  (.setPassword "DB-PASS")
+                                  ;; expire excess connections after 30 minutes of inactivity:
+                                  (.setMaxIdleTimeExcessConnections (* 30 60))
+                                  ;; expire connections after 3 hours of inactivity:
+                                  (.setMaxIdleTime (* 3 60 60)))}))
 
-    (defn pool
-      [spec]
-      (let [cpds (doto (ComboPooledDataSource.)
-                   (.setDriverClass (:classname spec)) 
-                   (.setJdbcUrl (str "jdbc:" (:subprotocol spec) ":" (:subname spec)))
-                   (.setUser (:user spec))
-                   (.setPassword (:password spec))
-                   ;; expire excess connections after 30 minutes of inactivity:
-                   (.setMaxIdleTimeExcessConnections (* 30 60))
-                   ;; expire connections after 3 hours of inactivity:
-                   (.setMaxIdleTime (* 3 60 60)))] 
-        {:datasource cpds}))
-
-Now you can create a single connection pool:
-
-    (def pooled-db (delay (pool db-spec)))
-    
-    (defn db-connection [] @pooled-db)
-
-And then call (db-connection) wherever you need access to it.
+And then call `@db` wherever you need access to it.


### PR DESCRIPTION
Simplified the connection pool example. The previous version used 1 hash and 3 functions. IMHO a call to @db in the code is better than calling a function to only deref it.

My 2 cents.
