### PR TITLE
fix IllegalArgEx: add :connection key in call to get-connection

### DIFF
--- a/src/main/clojure/clojure/java/jdbc.clj
+++ b/src/main/clojure/clojure/java/jdbc.clj
@@ -625,7 +625,7 @@ made at some future date." }
       (if-let [^java.sql.Connection con (db-find-connection db)]
         (with-open [^PreparedStatement stmt (apply prepare-statement con sql prepare-args)]
           (run-query-with-params stmt))
-        (with-open [^java.sql.Connection con (get-connection db)]
+        (with-open [^java.sql.Connection con (get-connection {:connection db})]
           (with-open [^PreparedStatement stmt (apply prepare-statement con sql prepare-args)]
             (run-query-with-params stmt)))))))
 


### PR DESCRIPTION
db-with-query-results*: get-connection destructures on :connection
