### PR TITLE
Update jdbc.clj

### DIFF
--- a/src/main/clojure/clojure/java/jdbc.clj
+++ b/src/main/clojure/clojure/java/jdbc.clj
@@ -641,7 +641,7 @@ made at some future date." }
     (fn [rs]
       (result-set-fn (if as-arrays?
                        (cons (first rs)
-                             (vec (map row-fn (rest rs))))
+                             (lazy-seq (map row-fn (rest rs))))
                        (map row-fn rs))))
     identifiers
     as-arrays?))


### PR DESCRIPTION
I want use as-array? options but the fn vec cause all resultset  realize,this may get a OOM Exception when handle a big resultset,I think the lazy-seq may a better implement
