### PR TITLE
add support for get-connection with :connection-uri and separate username/password

### DIFF
--- a/src/main/clojure/clojure/java/jdbc.clj
+++ b/src/main/clojure/clojure/java/jdbc.clj
@@ -241,6 +241,10 @@ http://clojure-doc.org/articles/ecosystem/java_jdbc/home.html"}
   Raw:
     :connection-uri (required) a String
                  Passed directly to DriverManager/getConnection
+                 Username and password can be part of the :connection-uri
+                 or passed separately.
+    :username    (optional) a String
+    :password    (optional) a String, required if :username is supplied
 
   Other formats accepted:
 
@@ -309,6 +313,10 @@ http://clojure-doc.org/articles/ecosystem/java_jdbc/home.html"}
 
      factory
      (-> (factory (dissoc db-spec :factory))
+         (modify-connection opts))
+
+     (and connection-uri username password)
+     (-> (DriverManager/getConnection connection-uri username password)
          (modify-connection opts))
 
      connection-uri


### PR DESCRIPTION
The `connection-uri` format forces to put username and password in the connection string which sometime it could be not ideal for security.
the `java.sql.DriverManager.getConnection()` supports a variant where the username and password are passed separately.

https://docs.oracle.com/javase/7/docs/api/java/sql/DriverManager.html#getConnection(java.lang.String,%20java.lang.String,%20java.lang.String)

adding this capability to `get-connection`. 