### PR TITLE
Update default-schema to handle table_id case

### DIFF
--- a/src/main/clojure/clojure/java/jdbc/datafy.clj
+++ b/src/main/clojure/clojure/java/jdbc/datafy.clj
@@ -51,7 +51,7 @@
   If a column name ends with _id or id, it is assumed to be a foreign key
   into the table identified by the first part of the column name."
   [col]
-  (let [[_ table] (re-find #"^(.*)_?id$" (name col))]
+  (let [[_ table] (re-find #"^(.*?)_?id$" (name col))]
     (when table
       [(keyword table) :id])))
 


### PR DESCRIPTION
Change makes table name wildcard less greedy so it doesn't eat "_" in "table_id" case.